### PR TITLE
Notes for Neuroconductor

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,3 +2,6 @@
 ^\.Rproj\.user$
 ^_pkgdown\.yml$
 ^docs$
+^\.travis\.yml$
+^appveyor\.yml$
+^README\.Rmd$

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ tests/testthat/testing_save_results/
 .Rproj.user
 Cindy*
 .DS_Store
+inst/doc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+# R for travis: see documentation at https://docs.travis-ci.com/user/languages/r
+
+language: R
+cache: packages

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,12 +1,16 @@
 Package: NDTr
 Title: The Neural Decoding Toolbox in R
 Version: 0.0.0.9001
-Authors@R: person("Ethan", "Meyers", email = "ethan.meyers@gmail.com", role = c("aut", "cre"))
+Authors@R: c(
+  person("Ethan", "Meyers", email = "ethan.meyers@gmail.com", 
+  role = c("aut", "cre"))
+  )
 Description: A package that allows one to do a neural decoding analysis in R. 
-  The package is based on 5 abstract object types: datasources (DS), features preprocessors (FP), 
-  classifiers (CL), and result matrics (RM) and cross-validators (CV). By combing different 
-  versions of these 4 object types together, it is possible to run a range of different decoding
-  analyses. See www.readout.info for more information. 
+    The package is based on 5 abstract object types: datasources (DS), 
+    features preprocessors (FP), classifiers (CL), and result matrics (RM) 
+    and cross-validators (CV). By combing different versions of these 4 object 
+    types together, it is possible to run a range of different decoding
+    analyses. See www.readout.info for more information. 
 URL: www.readout.info
 BugReports: https://github.com/emeyers/NDTr/issues
 Depends: R (>= 3.3.3)
@@ -26,5 +30,9 @@ Imports:
     magrittr,
     ggplot2,
     foreach
-Suggests: testthat
+Suggests: 
+    testthat,
+    knitr,
+    rmarkdown
 Encoding: UTF-8
+VignetteBuilder: knitr

--- a/NDTr.Rproj
+++ b/NDTr.Rproj
@@ -15,3 +15,4 @@ LaTeX: pdfLaTeX
 BuildType: Package
 PackageUseDevtools: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
+PackageRoxygenize: rd,collate,namespace,vignette

--- a/NDTr.Rproj
+++ b/NDTr.Rproj
@@ -15,4 +15,4 @@ LaTeX: pdfLaTeX
 BuildType: Package
 PackageUseDevtools: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
-PackageRoxygenize: rd,collate,namespace,vignette
+PackageRoxygenize: rd,collate,namespace

--- a/README.Rmd
+++ b/README.Rmd
@@ -12,7 +12,11 @@ knitr::opts_chunk$set(
 )
 ```
 
-
+<!-- badges: start -->
+[![Travis build status](https://travis-ci.com/muschellij2/NDTr.svg?branch=master)](https://travis-ci.com/muschellij2/NDTr)
+[![AppVeyor build status](https://ci.appveyor.com/api/projects/status/github/muschellij2/NDTr?branch=master&svg=true)](https://ci.appveyor.com/project/muschellij2/NDTr)
+<!-- badges: end -->
+  
 <p>
 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 
+<!-- badges: start -->
+
+[![Travis build
+status](https://travis-ci.com/muschellij2/NDTr.svg?branch=master)](https://travis-ci.com/muschellij2/NDTr)
+[![AppVeyor build
+status](https://ci.appveyor.com/api/projects/status/github/muschellij2/NDTr?branch=master&svg=true)](https://ci.appveyor.com/project/muschellij2/NDTr)
+<!-- badges: end -->
+
 <p>
 
 ## Description

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,52 @@
+# DO NOT CHANGE the "init" and "install" sections below
+
+# Download script file from GitHub
+init:
+  ps: |
+        $ErrorActionPreference = "Stop"
+        Invoke-WebRequest http://raw.github.com/krlmlr/r-appveyor/master/scripts/appveyor-tool.ps1 -OutFile "..\appveyor-tool.ps1"
+        Import-Module '..\appveyor-tool.ps1'
+
+install:
+  ps: Bootstrap
+
+cache:
+  - C:\RLibrary
+
+environment:
+  NOT_CRAN: true
+  # env vars that may need to be set, at least temporarily, from time to time
+  # see https://github.com/krlmlr/r-appveyor#readme for details
+  # USE_RTOOLS: true
+  # R_REMOTES_STANDALONE: true
+
+# Adapt as necessary starting from here
+
+build_script:
+  - travis-tool.sh install_deps
+
+test_script:
+  - travis-tool.sh run_tests
+
+on_failure:
+  - 7z a failure.zip *.Rcheck\*
+  - appveyor PushArtifact failure.zip
+
+artifacts:
+  - path: '*.Rcheck\**\*.log'
+    name: Logs
+
+  - path: '*.Rcheck\**\*.out'
+    name: Logs
+
+  - path: '*.Rcheck\**\*.fail'
+    name: Logs
+
+  - path: '*.Rcheck\**\*.Rout'
+    name: Logs
+
+  - path: '\*_*.tar.gz'
+    name: Bits
+
+  - path: '\*_*.zip'
+    name: Bits

--- a/vignettes/.gitignore
+++ b/vignettes/.gitignore
@@ -2,3 +2,5 @@ my_results/
 ZD_150bins_50sampled.Rda
 
 
+*.html
+*.R

--- a/vignettes/NDT_overview.Rmd
+++ b/vignettes/NDT_overview.Rmd
@@ -1,10 +1,10 @@
 ---
 title: "Tutorial"
-
-
-output: html_document
-  
-   
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{NDTr Overview}
+  %\VignetteEngine{knitr::rmarkdown}
+  \usepackage[utf8]{inputenc}
 ---
 
 ```{r setup, include=FALSE}

--- a/vignettes/feature_preprocessors.Rmd
+++ b/vignettes/feature_preprocessors.Rmd
@@ -2,7 +2,7 @@
 title: "Feature preprocessors"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{Datasources}
+  %\VignetteIndexEntry{Feature preprocessors}
   %\VignetteEngine{knitr::rmarkdown}
   \usepackage[utf8]{inputenc}
 ---

--- a/vignettes/introduction_tutorial.Rmd
+++ b/vignettes/introduction_tutorial.Rmd
@@ -1,4 +1,3 @@
-
 ---
 title: "Introduction to the NDTr"
 output: rmarkdown::html_vignette


### PR DESCRIPTION
Added continuous integration to the repo to see if the package checks out, here are the builds:
https://travis-ci.com/muschellij2/NDTr/builds

It looks like there are some errors and warnings.  

A few notes:
1. The repo size is quite substantial - over 500mb when cloned.
2. A lot of packages are straight imported, and Hadley recommendation from http://r-pkgs.had.co.nz/namespace.html is:
> Alternatively, if you are repeatedly using many functions from another package, you can import all of them using @import package. This is the least recommended solution because it makes your code harder to read (you can’t tell where a function is coming from), and if you @import many packages, it increases the chance of conflicting function names.
3.  Please see http://r-pkgs.had.co.nz/data.html for including data in a package.  The `data/` folder shouldn't have sub-folders.  Any non Rda files (e.g. the `.mat` files) should not be in the `data/` folder.
4. Some vignettes seem to be duplicated or were Rmd files, not really vignettes. 

I'd recommend using the `usethis` package.  I also have some notes here: https://johnmuschelli.com/neuroc/getting_ready_for_submission/index.html